### PR TITLE
Update license notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Pull requests are welcome. Please keep changes self‑contained and document any
 
 ## License
 
-This repository currently does not include a license file. When a `LICENSE` file is added, its terms will define how the project may be used and shared.
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- update the README license section to mention the MIT license

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b97dc6f483339d52e1cdfba4d062