### PR TITLE
Ignore Python bytecode directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ node_modules/
 # Temporary directories
 .tmp/
 
+# Python bytecode directories
+__pycache__/
+


### PR DESCRIPTION
## Summary
- keep bytecode out of the repo by ignoring `__pycache__/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b98512d4833385e9aa87bba9d890